### PR TITLE
Get-New-Hoaxes

### DIFF
--- a/src/api/apiCalls.js
+++ b/src/api/apiCalls.js
@@ -32,6 +32,17 @@ export const getOldHoaxes = (id, username) => {
   const path = username ? `/api/1.0/users/${username}/hoaxes/${id}` : `/api/1.0/hoaxes/${id}`
   return axios.get(path)
 }
+export const getNewHoaxes = (id, username) => {
+  const path = username ? `/api/1.0/users/${username}/hoaxes/${id}?direction=after` : `/api/1.0/hoaxes/${id}?direction=after`
+  return axios.get(path)
+}
+
+
+export const getNewHoaxCount = (id, username) => {
+  const path = username ? `/api/1.0/users/${username}/hoaxes/${id}?count=true` : `/api/1.0/hoaxes/${id}?count=true`
+  return axios.get(path);
+}
+
 
 
 

--- a/src/components/HoaxFeed.js
+++ b/src/components/HoaxFeed.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useEffect } from 'react';
 import { useState } from 'react';
-import { getHoaxes, getOldHoaxes } from '../api/apiCalls'
+import { getHoaxes, getNewHoaxCount, getNewHoaxes, getOldHoaxes } from '../api/apiCalls'
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom'
 import HoaxView from './HoaxView';
@@ -16,9 +16,13 @@ const HoaxFeed = () => {
         number: 0,
     })
     const { username } = useParams()
+    const [newHoaxCount, setNewHoaxCount] = useState(0);
 
     let lastHoaxId = 0
+    let firstHoaxId = 0
     if (hoaxPage.content.length > 0) {
+        firstHoaxId = hoaxPage.content[0].id
+
         const lastHoaxIndex = hoaxPage.content.length - 1;
         lastHoaxId = hoaxPage.content[lastHoaxIndex].id
     }
@@ -28,6 +32,9 @@ const HoaxFeed = () => {
 
     const oldHoaxPath = username ? `/api/1.0/${username}/hoaxes/${lastHoaxId}` : `/api/1.0/hoaxes/${lastHoaxId}`
     const loadOldHoaxesProgress = useApiProgress('get', oldHoaxPath, true)
+
+    const newHoaxPath = username ? `/api/1.0/users/${username}/hoaxes/${firstHoaxId}?direction=after` : `/api/1.0/hoaxes/${firstHoaxId}?direction=after`
+    const loadNewHoaxesProgress = useApiProgress('get', newHoaxPath, true)
 
     useEffect(() => {
         const loadHoaxes = async (page) => {
@@ -43,16 +50,38 @@ const HoaxFeed = () => {
         loadHoaxes()
     }, [username]) //sadece mount anında çalış
 
+    useEffect(() => {
+        const getCount = async () => {
+            const response = await getNewHoaxCount(firstHoaxId, username);
+            setNewHoaxCount(response.data.count)
+        } // Sürekli olarak bir işlem yaptırdık ve aynı işlem birden fazla kez çağrılmaya çalışırsa temizlensin tekrar atmasın diye cleanup yaptık
+        let looper = setInterval(getCount, 5000)
+        return function cleanup() {
+            clearInterval(looper)
+        }
+
+    }, [firstHoaxId, username])
+
     const loadOldHoaxes = async () => {
 
         const response = await getOldHoaxes(lastHoaxId, username)
 
-        setHoaxPage(previousHoaxes => ({
+        setHoaxPage(previousHoaxesPage => ({
             ...response.data,
-            content: [...previousHoaxes.content, ...response.data.content]
+            content: [...previousHoaxesPage.content, ...response.data.content]
 
         })) //response.data bize JSON objesini verir
 
+    }
+    const loadNewHoaxes = async () => {
+        const response = await getNewHoaxes(firstHoaxId, username)
+        setHoaxPage(previousHoaxesPage => (
+            {
+                ...previousHoaxesPage,
+                content: [...response.data, ...previousHoaxesPage.content]
+            }
+        ))
+        setNewHoaxCount(0)
     }
 
 
@@ -71,6 +100,12 @@ const HoaxFeed = () => {
 
     return (
         <div>
+            {newHoaxCount > 0 && (
+                <div className='alert alert-secondary text-center mt-2'
+                    style={{ cursor: loadOldHoaxesProgress ? 'not-allowed' : 'pointer' }}
+                    onClick={loadOldHoaxesProgress ? () => { } : loadNewHoaxes}>
+                    {loadNewHoaxesProgress ? <Spinner /> : t('There are new hoaxes')}
+                </div>)}
             {content.map(hoax => {
                 return <HoaxView key={hoax.id} hoax={hoax} />
             })}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -27,6 +27,7 @@ i18n.use(initReactI18next).init({
         'There are no hoaxes': 'There are no hoaxes',
         'Load old hoaxes': 'Load old hoaxes',
         'Scale Down': 'Scale Down',
+        'There are new hoaxes': 'There are new hoaxes',
       }
     },
     tr: {
@@ -52,6 +53,7 @@ i18n.use(initReactI18next).init({
         'There are no hoaxes': 'Hoax bulunamadı',
         'Load old hoaxes': 'Geçmiş hoaxları getir',
         'Scale Down': 'Küçült',
+        'There are new hoaxes': 'Yeni hoaxlar mevcut',
       }
     }
   },


### PR DESCRIPTION
Yeni hoaxlar yüklenince bunları client'imize en doğru şekilde getirmeyi yaptık. Önceden yaptığımız gibi en son ve en baştaki hoaxların id'sini tutarak eğer bunların üstüne bir değişiklik yapılmışsa işlemleri bu id'ye göre yaparak duplicate hatalarından kurtulmuş olduk. Artık yeni bir hoax atılınca her 5 saniyede bir fark ediliyor ve load new hoaxes'a tıklayarak güncel hoaxları alabiliyoruz.